### PR TITLE
Capitalize by 'tr' instead of variable substitution.

### DIFF
--- a/resources/scripts/ibcstart.sh
+++ b/resources/scripts/ibcstart.sh
@@ -154,8 +154,9 @@ if [[ -n "${fix_user_id}" || -n "${fix_password}" ]]; then
 	fi
 fi
 
-if [[ -n "${mode}" && ! "${mode^^}" = "LIVE" && ! "${mode^^}" = "PAPER" ]]; then
-	error_exit	${E_INVALID_ARG} "Trading mode set to ${mode} but must be either 'live' or 'paper'"
+mode_upper=$(echo ${mode} | tr '[:lower:]' '[:upper:]')
+if [[ -n "${mode_upper}" && ! "${mode_upper}" = "LIVE" && ! "${mode_upper}" = "PAPER" ]]; then
+	error_exit	${E_INVALID_ARG} "Trading mode set to ${mode} but must be either 'live' or 'paper' (case-insensitive)"
 fi
 
 echo


### PR DESCRIPTION
macOS ships a bash 3.x, which does not support '^^'. '^^' variable substitution is added in bash 5.x.

My macOS is 10.15.4.
<img width="422" alt="Screen Shot 2020-03-29 at 9 11 35 PM" src="https://user-images.githubusercontent.com/423108/77874486-e4f4be80-7201-11ea-8fa5-9e49b7b48ade.png">

and bash version is 3.2.57.
<img width="546" alt="Screen Shot 2020-03-29 at 9 09 40 PM" src="https://user-images.githubusercontent.com/423108/77874390-a101b980-7201-11ea-959f-60bd7f06a88b.png">
