### PR TITLE
Only handle Second Factor Authentication dialog while ReadOnlyLogin mode is off, otherwise click button 'read only login'.

### DIFF
--- a/src/ibcalpha/ibc/TwsListener.java
+++ b/src/ibcalpha/ibc/TwsListener.java
@@ -79,7 +79,9 @@ class TwsListener
                     if (eventID == WindowEvent.WINDOW_OPENED) {
                         Utils.logRawToConsole(SwingUtils.getWindowStructure(window));
                     }
-                } else if (SwingUtils.titleContains(window, "Second Factor Authentication")) {
+                } else if (Settings.settings().getBoolean("ReadOnlyLogin", false)) == false &&
+                        SwingUtils.titleContains(window, "Second Factor Authentication")) {
+                    // Only handle SFA while ReadOnlyLogin mode is off.
                     Utils.logToConsole("Second Factor Authentication dialog event: " + SwingUtils.windowEventToString(eventID));
                     if (eventID == WindowEvent.WINDOW_OPENED) {
                         Utils.logToConsole("Second Factor Authentication dialog opened");

--- a/src/ibcalpha/ibc/TwsListener.java
+++ b/src/ibcalpha/ibc/TwsListener.java
@@ -79,8 +79,8 @@ class TwsListener
                     if (eventID == WindowEvent.WINDOW_OPENED) {
                         Utils.logRawToConsole(SwingUtils.getWindowStructure(window));
                     }
-                } else if (Settings.settings().getBoolean("ReadOnlyLogin", false)) == false &&
-                        SwingUtils.titleContains(window, "Second Factor Authentication")) {
+                } else if (SwingUtils.titleContains(window, "Second Factor Authentication") &&
+                        ! Settings.settings().getBoolean("ReadOnlyLogin", false))
                     // Only handle SFA while ReadOnlyLogin mode is off.
                     Utils.logToConsole("Second Factor Authentication dialog event: " + SwingUtils.windowEventToString(eventID));
                     if (eventID == WindowEvent.WINDOW_OPENED) {


### PR DESCRIPTION
For some types of accounts (2 out of 3 of mine), readonly mode does not work properly because 'read only login' shows up in 'Second Factor Authentication' window but not in a no-title dialog.

With this fix it works for all accounts.