### PR TITLE
add [primaryalways] mode for ExistingSessionDetectedDialogHandler

### DIFF
--- a/src/ibcalpha/ibc/ExistingSessionDetectedDialogHandler.java
+++ b/src/ibcalpha/ibc/ExistingSessionDetectedDialogHandler.java
@@ -18,9 +18,9 @@
 
 package ibcalpha.ibc;
 
-import java.awt.Window;
+import javax.swing.*;
+import java.awt.*;
 import java.awt.event.WindowEvent;
-import javax.swing.JDialog;
 
 public class ExistingSessionDetectedDialogHandler implements WindowHandler {
 
@@ -46,26 +46,26 @@ public class ExistingSessionDetectedDialogHandler implements WindowHandler {
             } else {
                 Utils.logToConsole("End the other session and continue this one");
                 hasTakenOverAnotherSession = true;
-                if (!SwingUtils.clickButton(window, "OK") && 
+                if (!SwingUtils.clickButton(window, "OK") &&
                         !SwingUtils.clickButton(window, "Continue Login") &&
-                        !SwingUtils.clickButton(window, "Reconnect This Session"))  {
+                        !SwingUtils.clickButton(window, "Reconnect This Session")) {
                     Utils.logError("could not handle 'Existing session detected' dialog because the 'OK' or 'Continue Login' or 'Reconnect This Session' button wasn't found.");
                 }
             }
         } else if (setting.equalsIgnoreCase("primaryoverride")) {
-            if (LoginManager.loginManager().getLoginState() != LoginManager.LoginState.LOGGED_IN){
+            if (LoginManager.loginManager().getLoginState() != LoginManager.LoginState.LOGGED_IN) {
                 /* The login has not yet been completed, so this is a new IBC instance
                    and we must continue this one and let the other one finish
                 */
                 Utils.logToConsole("End the other session and continue this one");
-                if (!SwingUtils.clickButton(window, "OK") && 
+                if (!SwingUtils.clickButton(window, "OK") &&
                         !SwingUtils.clickButton(window, "Continue Login") &&
-                        !SwingUtils.clickButton(window, "Reconnect This Session"))  {
+                        !SwingUtils.clickButton(window, "Reconnect This Session")) {
                     Utils.logError("could not handle 'Existing session detected' dialog because the 'OK' or 'Continue Login' or 'Reconnect This Session' button wasn't found.");
                 }
             } else {
                 /* The login has already been completed, and the ExistingSessionDetected
-                   dialog is in response to handing the ReLogin dialog after a new 
+                   dialog is in response to handing the ReLogin dialog after a new
                    primary or primaryoverride IBC was started. We must terminate this
                    instance and let the other one proceed
                 */
@@ -73,6 +73,13 @@ public class ExistingSessionDetectedDialogHandler implements WindowHandler {
                 if (!SwingUtils.clickButton(window, "Cancel") && !SwingUtils.clickButton(window, "Exit Application")) {
                     Utils.logError("could not handle 'Existing session detected' dialog because the 'Cancel' or 'Exit Application' button wasn't found.");
                 }
+            }
+        } else if (setting.equalsIgnoreCase("primaryalways")) {
+            Utils.logToConsole("End the other session and continue this one");
+            if (!SwingUtils.clickButton(window, "OK") &&
+                    SwingUtils.clickButton(window, "Continue Login") &&
+                    SwingUtils.clickButton(window, "Reconnect This Session")) {
+                Utils.logError("could not handle 'Existing session detected' dialog because the 'OK' or 'Continue Login' or 'Reconnect This Session' button wasn't found.");
             }
         } else if (setting.equalsIgnoreCase("secondary")) {
             Utils.logToConsole("End this session and let the other session proceed");
@@ -88,7 +95,7 @@ public class ExistingSessionDetectedDialogHandler implements WindowHandler {
     }
 
     public boolean recogniseWindow(Window window) {
-        if (! (window instanceof JDialog)) return false;
+        if (!(window instanceof JDialog)) return false;
 
         return (SwingUtils.titleContains(window, "Existing session detected"));
     }


### PR DESCRIPTION
Sometimes it's required to reset a secondary session all the time.
This PR adds a new mode - **primaryalways**.