### PR TITLE
hide credentials in System Properties printout

### DIFF
--- a/src/ibcalpha/ibc/IbcTws.java
+++ b/src/ibcalpha/ibc/IbcTws.java
@@ -408,7 +408,16 @@ public class IbcTws {
         Utils.logRawToConsole("------------------------------------------------------------");
         while (i.hasMoreElements()) {
             String props = (String) i.nextElement();
-            Utils.logRawToConsole(props + " = " + (String) p.get(props));
+            String vals = (String) p.get(props);
+            if (props.equals("sun.java.command")) {
+                //hide credentials 
+                String[] args = vals.split(" ");
+                for (int j = 2; j < args.length - 1; j++) {
+                    args[j] = "***";
+                }
+                vals = String.join(" ", args);
+            }
+            Utils.logRawToConsole(props + " = " + vals);
         }
         Utils.logRawToConsole("------------------------------------------------------------");
     }


### PR DESCRIPTION
To be consistent with .sh/.bat files hiding credentials 
System Properties printout also hides credentials in case credentials are part of the command arguments

AJ
PS. My first ever java code. Code works for me, however if I missed something. Happy to get comments