### PR TITLE
upload diagnostics if asked

### DIFF
--- a/resources/config.ini
+++ b/resources/config.ini
@@ -369,7 +369,14 @@ AcceptBidAskLastSizeDisplayUpdateNotification=
 
 SendMarketDataInLotsForUSstocks=
 
+# Sometimes the gateway runs into problems
+# and asks about diagnostics upload to IB.
+# 'yes' - allow to upload diagnostics
+# not set - ignore the dialog box.
+# The dialog is "harmless" and is not blocking any operation.
+# However setting "yes" would increase chances that IB fixes the problem.
 
+UploadIBDiagnosticsBundleIfAsked=
 
 # =============================================================================
 # 4.   TWS Auto-Closedown

--- a/src/ibcalpha/ibc/DiagnosticsUploadDialogHandler.java
+++ b/src/ibcalpha/ibc/DiagnosticsUploadDialogHandler.java
@@ -1,0 +1,64 @@
+// This file is part of IBC.
+// Copyright (C) 2004 Steven M. Kearns (skearns23@yahoo.com )
+// Copyright (C) 2004 - 2018 Richard L King (rlking@aultan.com)
+// For conditions of distribution and use, see copyright notice in COPYING.txt
+
+// IBC is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// IBC is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with IBC.  If not, see <http://www.gnu.org/licenses/>.
+
+package ibcalpha.ibc;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.WindowEvent;
+import java.lang.reflect.Type;
+import java.util.regex.Pattern;
+
+class DiagnosticsUploadDialogHandler implements WindowHandler {
+    public boolean filterEvent(Window window, int eventId) {
+        switch (eventId) {
+            case WindowEvent.WINDOW_OPENED:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    public void handleWindow(Window window, int eventID) {
+        if (uploaded) {
+            Utils.logError("TODO. Second upload request. Will upload diagnostics only once");
+        }
+        else
+        {
+            String accept = Settings.settings().getString("UploadIBDiagnosticsBundleIfAsked", "");
+            switch(accept) {
+                case "yes":
+                    uploaded = true;
+                    if (!SwingUtils.clickButton(window, "Send Diagnostics Bundle")) {
+                        Utils.logError("could not upload diagnostics");
+                    }
+                    return;
+                default:
+                    Utils.logError("UploadIBDiagnosticsBundleIfAsked : " + accept);
+                    return;
+            }
+        }
+    }
+
+    public boolean recogniseWindow(Window window) {
+        if (! (window instanceof JFrame)) return false;
+        return SwingUtils.getWindowTitle(window).equals("Trader Workstation - diagnostics upload");
+    }
+
+    private boolean uploaded = false;
+}

--- a/src/ibcalpha/ibc/IbcTws.java
+++ b/src/ibcalpha/ibc/IbcTws.java
@@ -333,7 +333,7 @@ public class IbcTws {
         windowHandlers.add(new ShutdownProgressDialogHandler());
         windowHandlers.add(new BidAskLastSizeDisplayUpdateDialogHandler());
         windowHandlers.add(new LoginErrorDialogHandler());
-        
+        windowHandlers.add(new DiagnosticsUploadDialogHandler());
         return windowHandlers;
     }
 


### PR DESCRIPTION
In case gateway runs into internal problem it asks for diagnostics upload. 
The dialog looks like this (has been there for me since 10.10 and only in financial advisor mode):
![image](https://user-images.githubusercontent.com/2228878/141111729-9800d162-c3e4-4a92-8215-00700b2b2165.png)

Would be great to allow to automatically submit that diagnostics to increase chances of IB actually fixing the problem.

The default mode: the dialog is ignored. if user activelly sets UploadIBDiagnosticsBundleIfAsked=yes, then the diagnostics gets uploaded.

I've been running this code in my production for about a month with no issues. 