### PR TITLE
Fix recogniseWindow for GatewayLogin

### DIFF
--- a/src/ibcalpha/ibc/GatewayLoginFrameHandler.java
+++ b/src/ibcalpha/ibc/GatewayLoginFrameHandler.java
@@ -28,12 +28,10 @@ final class GatewayLoginFrameHandler extends AbstractLoginHandler {
     public boolean recogniseWindow(Window window) {
         if (! (window instanceof JFrame)) return false;
 
-        return ((SwingUtils.titleContains(window, "IBKR Gateway") ||
-                    SwingUtils.titleContains(window, "IB Gateway") || 
-                    SwingUtils.titleContains(window, "Interactive Brokers Gateway")) &&
+        return SwingUtils.titleContains(window, "Gateway") &&
                (SwingUtils.findButton(window, "Login") != null ||
                 SwingUtils.findButton(window, "Log In") != null ||          // TWS 974+
-                SwingUtils.findButton(window, "Paper Log In") != null));    // TWS 974+
+                SwingUtils.findButton(window, "Paper Log In") != null);     // TWS 974+
     }
 
     @Override


### PR DESCRIPTION
The Title in IB Gateway constantly changing.
Previously, the titles were "IB Gateway" and "Interactive Brokers Gateway", buy now Titile is "IBKR Gateway".
Therefore, I combined all similar Titles to "Gateway".