### PR TITLE
Update userguide.md

### DIFF
--- a/userguide.md
+++ b/userguide.md
@@ -130,10 +130,10 @@ up and running properly.
       Build 10.19.1f, Oct 28, 2022 3:03:08 PM
    ```
 
-   For Windows and Linux,  the major version number is 1019 (ie ignore the
+   For Windows and Linux, the major version number for the above example would be 1019 (ie ignore the
    period after the first part of the version number).
 
-   For macOS, the major version number is 10.19. (Note that this is different
+   For macOS, the major version number for the above example would be 10.19. (Note that this is different
    from the equivalent Windows and Linux settings because the macOS installer
    includes the period in the install folder name).
 


### PR DESCRIPTION
To make it clearer that the major version changes. I installed IBC around 2 years ago in 2023 when the major offline version was 10.19. I am reinstalling IBC on a new machine and as of today the major offline version is 10.30. I was a bit confused at first because 10.19 wasn't available on the IBKR website anymore and the wording in the IBC user guide made it seem like it only works for TWS offline 10.19. IBC is working just fine with 10.30 so I think slightly changing the wording here is beneficial.