### PR TITLE
feat: Force exit after shutdown

### DIFF
--- a/src/ibcalpha/ibc/StopTask.java
+++ b/src/ibcalpha/ibc/StopTask.java
@@ -84,9 +84,22 @@ class StopTask
                 String[] closeMenuPath = SessionManager.isGateway() ? new String[] {"File", "Close"} : new String[] {"File", "Exit"};
                 Utils.logToConsole("Login has completed: exiting via " + Arrays.deepToString(closeMenuPath) + " menu");
                 Utils.invokeMenuItem(MainWindowManager.mainWindowManager().getMainWindow(), closeMenuPath);
+                MyScheduledExecutorService.getInstance().shutdownNow();
+                MyCachedThreadPool.getInstance().shutdownNow();
+                CommandServer.commandServer().shutdown();
+                new Thread() {
+                    @Override
+                    public void run() {
+                        try {
+                            Thread.sleep(5000);
+                        } catch (InterruptedException ex) {
+                        }
+                        System.exit(0);
+                    }
+                }.start();
             }
-            
         } catch (Exception e) {
+            // ignore
         }
     }
 


### PR DESCRIPTION
Force the application to exit after a 5-second delay to ensure a clean shutdown.

Sometimes ibc can't fully close existing tws and blocking start new one. Yesterday I saw this error msg

2025-10-14 03:35:47,052 pool-3-thread-1 ERROR Attempted to append to non-started appender h
2025-10-14 03:35:47,068 Thread-41 ERROR Attempted to append to non-started appender h

Gemini give me this suggestion.