### PR TITLE
Remove hardcoded telnet path for improved portability

### DIFF
--- a/resources/commandsend.sh
+++ b/resources/commandsend.sh
@@ -32,6 +32,6 @@ if [[ -z "$1" ]]; then
 fi
 
 # send the required command to IBC 
-(echo "$1"; sleep 1; echo "EXIT"; echo "quit" ) | /usr/local/bin/telnet "$server_address" $command_server_port
+(echo "$1"; sleep 1; echo "EXIT"; echo "quit" ) | telnet "$server_address" $command_server_port
 
 


### PR DESCRIPTION
Remove hardcoded telnet path `/usr/local/bin/telenet`, default linux path for telnet is `/usb/bin/telnet` this will make `commandsend.sh` work in most, if not all, linux distributions.

there is no harm in removing the path prefix, as long as telnet is in PATH the shell will find it.

this is realted to https://github.com/gnzsnz/ib-gateway-docker/issues/322