### PR TITLE
Add handler for Unrecognized Username or Password dialog

### DIFF
--- a/src/ibcalpha/ibc/IbcTws.java
+++ b/src/ibcalpha/ibc/IbcTws.java
@@ -332,6 +332,7 @@ public class IbcTws {
         windowHandlers.add(new ExitConfirmationDialogHandler());
         windowHandlers.add(new TradingLoginHandoffDialogHandler());
         windowHandlers.add(new LoginFailedDialogHandler());
+        windowHandlers.add(new UnrecognizedUsernameOrPasswordDialogHandler());
         windowHandlers.add(new TooManyFailedLoginAttemptsDialogHandler());
         windowHandlers.add(new ShutdownProgressDialogHandler());
         windowHandlers.add(new BidAskLastSizeDisplayUpdateDialogHandler());

--- a/src/ibcalpha/ibc/UnrecognizedUsernameOrPasswordDialogHandler.java
+++ b/src/ibcalpha/ibc/UnrecognizedUsernameOrPasswordDialogHandler.java
@@ -1,0 +1,55 @@
+// This file is part of IBC.
+// Copyright (C) 2004 Steven M. Kearns (skearns23@yahoo.com )
+// Copyright (C) 2004 - 2020 Richard L King (rlking@aultan.com)
+// For conditions of distribution and use, see copyright notice in COPYING.txt
+
+// IBC is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// IBC is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with IBC.  If not, see <http://www.gnu.org/licenses/>.
+
+package ibcalpha.ibc;
+
+import java.awt.Window;
+import java.awt.event.WindowEvent;
+import javax.swing.JDialog;
+
+public class UnrecognizedUsernameOrPasswordDialogHandler implements WindowHandler {
+    final String DIALOG_TITLE = "Unrecognized Username or Password";
+
+    @Override
+    public boolean filterEvent(Window window, int eventId) {
+        switch (eventId) {
+            case WindowEvent.WINDOW_OPENED:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    @Override
+    public void handleWindow(Window window, int eventID) {
+        Utils.logToConsole("Unrecognized Username or Password");
+        Utils.logToConsole("Cold restart in progress");
+        MyCachedThreadPool.getInstance().execute(new StopTask(null, true, "Cold restart after Unrecognized Username or Password dialog encountered"));
+
+        if (! SwingUtils.clickButton(window, "OK")) {
+            Utils.logError("could not dismiss Unrecognized Username or Password dialog because we could not find the OK button");
+        }
+    }
+
+    @Override
+    public boolean recogniseWindow(Window window) {
+        if (! (window instanceof JDialog)) return false;
+
+        return (SwingUtils.titleContains(window, DIALOG_TITLE));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a new `UnrecognizedUsernameOrPasswordDialogHandler` that detects when TWS/Gateway shows the "Unrecognized Username or Password" dialog
- The handler logs the error, clicks OK to dismiss the dialog, and initiates a cold restart to recover automatically
- Registers the handler in `IbcTws.java` between `LoginFailedDialogHandler` and `TooManyFailedLoginAttemptsDialogHandler`

## Problem

When TWS/Gateway encounters an "Unrecognized Username or Password" error, IBC has no handler for this specific dialog. This causes the application to hang indefinitely in unattended environments, requiring manual intervention to restart.

## Solution

The new handler follows the same pattern as existing dialog handlers (e.g., `LoginFailedDialogHandler`). When the dialog is detected:
1. Logs the error to console
2. Initiates a cold restart via `StopTask`
3. Clicks OK to dismiss the dialog

This enables fully unattended recovery from transient authentication failures.

## Test plan

- [ ] Verify the handler correctly identifies the "Unrecognized Username or Password" dialog
- [ ] Verify cold restart is triggered when the dialog appears
- [ ] Verify the OK button is clicked to dismiss the dialog
- [ ] Verify no regression in existing login failure handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)