### PR TITLE
Spell out IBC as Interactive Brokers Controller in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 **Download the
 [latest official release here](https://github.com/IbcAlpha/IBC/releases/latest)**
 
-IBC automates many aspects of running [Interactive Brokers](https://www.interactivebrokers.com) [Trader Workstation and Gateway](https://www.interactivebrokers.com/en/index.php?f=14099#tws-software)
+IBC (Interactive Brokers Controller) automates many aspects of running [Interactive Brokers](https://www.interactivebrokers.com) [Trader Workstation and Gateway](https://www.interactivebrokers.com/en/index.php?f=14099#tws-software)
 that would otherwise involve manual intervention. It's especially useful for
 those who run automated trading systems based on the [Interactive Brokers API](http://interactivebrokers.github.io),
 but many manual traders find it helpful as well.


### PR DESCRIPTION
To help new users. Surprisingly, the acronym wasn't spelled out explicitly in the README.