### PR TITLE
Avoid spurious error messages when checking for autorestart

### DIFF
--- a/resources/scripts/StartIBC.bat
+++ b/resources/scripts/StartIBC.bat
@@ -540,7 +540,7 @@ echo Finding autorestart file
 set AUTORESTART_OPTION=
 set F=
 set RESTART_NEEDED=
-for /f "usebackq delims=" %%I in (`where /R "%TWS_SETTINGS_PATH%" autorestart`) do (
+for /f "usebackq delims=" %%I in (`where /R "%TWS_SETTINGS_PATH%" autorestart 2^>nul`) do (
 	set X=%%~dpI.
 	set Y=!X:%TWS_SETTINGS_PATH%=!
 	for /f "tokens=1,2 delims=\" %%B in ("!!Y!!") do (


### PR DESCRIPTION
Normal run results in the following log messages:
```
Finding autorestart file
INFO: Could not find files for the given pattern(s).
autorestart file not found: full authentication will be required
```
This looks like there is some error with some command. This change makes sure "Could not find files for the given pattern(s)." line is removed