### PR TITLE
Stop leaking IB password to IBC log when passed via env vars

### DIFF
--- a/src/ibcalpha/ibc/IbcTws.java
+++ b/src/ibcalpha/ibc/IbcTws.java
@@ -454,9 +454,9 @@ public class IbcTws {
             String props = (String) i.nextElement();
             String vals = (String) p.get(props);
             if (props.equals("sun.java.command")) {
-                //hide credentials 
+                //hide credentials
                 String[] args = vals.split(" ");
-                for (int j = 2; j < args.length - 1; j++) {
+                for (int j = 2; j < args.length; j++) {
                     args[j] = "***";
                 }
                 vals = String.join(" ", args);


### PR DESCRIPTION
TWSUSERID/TWSPASSWORD (or /User:/PW:) ended up in clear in every launch's System Properties dump. Config-file IbLoginId/IbPassword was unaffected.