### PR TITLE
Pass -DjxBrowserKey to the Gateway/TWS JVM so passkey (WebAuthn) 2FA can render

### DIFF
--- a/resources/scripts/StartIBC.bat
+++ b/resources/scripts/StartIBC.bat
@@ -370,6 +370,26 @@ set JAVA_VM_OPTIONS=%JAVA_VM_OPTIONS% -DjtsConfigDir="%TWS_SETTINGS_PATH%"
 set IBC_SESSION_ID="%RANDOM%%RANDOM%"
 set JAVA_VM_OPTIONS=%JAVA_VM_OPTIONS% -Dibcsessionid=%IBC_SESSION_ID%
 
+rem The TWS/Gateway desktop login renders passkey (WebAuthn) second-factor authentication in
+rem an embedded browser (JxBrowser). The official install4j launcher starts the JVM with
+rem -DjxBrowserKey=<license key>; IBC builds its own java command and so omits it. Without the
+rem key, JxBrowser cannot initialise ("Failed to create browser") and passkey login fails. As
+rem IBKR Securities Japan makes passkey the only login 2FA from 2026-06-30, IBC must pass this
+rem key too. It is embedded in the install and is version-specific, so read it dynamically.
+rem This does NOT bypass 2FA - the user still completes the passkey ceremony.
+set "JXBROWSER_OPT="
+if exist "%INSTALL4J%\i4jparams.conf" (
+	for /f "usebackq delims=" %%L in (`findstr /C:"-DjxBrowserKey=" "%INSTALL4J%\i4jparams.conf"`) do (
+		rem Keep everything after the first -DjxBrowserKey= . In i4jparams.conf the key is
+		rem terminated by a double-quote, so replace that quote with a space and take token 1.
+		set "JXLINE=%%L"
+		set "JXTAIL=!JXLINE:*-DjxBrowserKey=!"
+		set JXTAIL=!JXTAIL:"= !
+		for /f "tokens=1" %%K in ("!JXTAIL!") do set "JXBROWSER_OPT=-DjxBrowserKey=%%K"
+	)
+)
+if defined JXBROWSER_OPT set "JAVA_VM_OPTIONS=%JAVA_VM_OPTIONS% %JXBROWSER_OPT%"
+
 echo Java VM Options=%JAVA_VM_OPTIONS%
 echo.
 

--- a/resources/scripts/ibcstart.sh
+++ b/resources/scripts/ibcstart.sh
@@ -343,6 +343,23 @@ java_vm_options="$java_vm_options -DjtsConfigDir=${tws_settings_path}"
 ibc_session_id=$(mktemp -u XXXXXXXX)
 java_vm_options="$java_vm_options -Dibcsessionid=$ibc_session_id"
 
+# The TWS/Gateway desktop login renders passkey (WebAuthn) second-factor authentication in an
+# embedded browser (JxBrowser). The official install4j launcher starts the JVM with
+# -DjxBrowserKey=<license key>; IBC builds its own java command and so omits it. Without the
+# key, JxBrowser cannot initialise (IllegalArgumentException in EngineOptions.licenseKey ->
+# "Failed to create browser") and passkey login fails. As IBKR Securities Japan makes passkey
+# the only login 2FA from 2026-06-30, IBC must pass this key too. It is embedded in the
+# install and is version-specific, so read it dynamically rather than hardcoding. This does
+# NOT bypass 2FA - the user still completes the passkey ceremony.
+if [[ -z "$jxbrowser_key" && -r "${install4j}/i4jparams.conf" ]]; then
+	# The key sits in i4jparams.conf as -DjxBrowserKey=<key>" (terminated by a quote/space);
+	# capture it up to that terminator so the whole key is taken regardless of its characters.
+	jxbrowser_key=$(grep -aoE 'DjxBrowserKey=[^" ]+' "${install4j}/i4jparams.conf" | head -n 1 | sed 's/^DjxBrowserKey=//')
+fi
+if [[ -n "$jxbrowser_key" ]]; then
+	java_vm_options="$java_vm_options -DjxBrowserKey=$jxbrowser_key"
+fi
+
 echo -e "Java VM Options=$java_vm_options$autorestart_option"
 
 function find_auto_restart {


### PR DESCRIPTION
Fixes #362.

### What

When a desktop Gateway/TWS login requires a **passkey (WebAuthn)** second factor, the ceremony is rendered in an embedded browser (JxBrowser). The official install4j launcher starts the JVM with `-DjxBrowserKey=<license key>`, but IBC builds its own java command (`ibcstart.sh` / `StartIBC.bat`) and omits it — so JxBrowser fails to initialise (`EngineOptions.licenseKey()` → "Failed to create browser") and the passkey dialog never renders. (`ibcstart.sh` also strips every `-D` line out of `.vmoptions`, so the key can't be added there.)

This reads the key dynamically from `<install>/.install4j/i4jparams.conf` (it is version-specific → not hardcoded) and appends `-DjxBrowserKey=` to the VM options. It is a **no-op when the file/key is absent**, so non-passkey installs and older builds are unaffected. It restores parity with the official launcher.

### Not a 2FA bypass

This does **not** bypass or automate 2FA — it only restores a JVM flag the official launcher already passes, so the ceremony can render. IBC does not intervene in the passkey ceremony (cf. #342); the user still completes it.

### Motivation

IBKR Securities Japan makes passkey the **only** login 2FA from **2026-06-30** (IB Key push dropped), so headless Gateway users on JP accounts hit this now; it affects any passkey-required account.

### Testing

- **Unix `ibcstart.sh`: validated end-to-end** on IB Gateway 10.47.1d (Ubuntu 24.04, headless Xvfb). With the key injected, the log shows `Browser created successfully`, the WebAuthn ceremony renders, the USB security key is detected, and it reaches the "PIN required" prompt.
- ⚠️ **Windows `StartIBC.bat`: UNTESTED on a real Windows environment.** The change mirrors the Unix logic (extract the key from `i4jparams.conf`, append `-DjxBrowserKey=`), but I don't have Windows to verify the batch parsing — **please review/test the `.bat` before relying on it.**

### Scope note (transparency)

This fixes *rendering* of the ceremony. On headless **Linux** specifically, *typing* the FIDO2 PIN into the embedded WebAuthn dialog is blocked by a separate JxBrowser/Chromium-popup keyboard-focus issue that is independent of IBC (the embedded dialog is an override-redirect Chromium popup that never takes X keyboard focus; it works on Windows/macOS). That is out of scope here and is not something IBC can fix in the launch scripts.
