### PR TITLE
Recognise IB Gateway 1037+ login controls (hyphenated forms)

### DIFF
--- a/src/ibcalpha/ibc/AbstractLoginHandler.java
+++ b/src/ibcalpha/ibc/AbstractLoginHandler.java
@@ -25,6 +25,7 @@ import java.util.concurrent.TimeUnit;
 import javax.swing.JButton;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
+import javax.swing.JToggleButton;
 
 public abstract class AbstractLoginHandler implements WindowHandler {
 
@@ -157,6 +158,7 @@ public abstract class AbstractLoginHandler implements WindowHandler {
         JButton b = SwingUtils.findButton(window, "Login");
         if (b == null) b = SwingUtils.findButton(window, "Log In");
         if (b == null) b = SwingUtils.findButton(window, "Paper Log In");
+        if (b == null) b = SwingUtils.findButton(window, "Paper-Login");    // Gateway 1037+ (hyphenated)
         return b;
     }
 
@@ -174,14 +176,18 @@ public abstract class AbstractLoginHandler implements WindowHandler {
     protected final boolean setTradingMode(final Window window) {
         String tradingMode = TradingModeManager.tradingModeManager().getTradingMode();
 
-        if (SwingUtils.findToggleButton(window, "Live Trading") != null && 
-                SwingUtils.findToggleButton(window, "Paper Trading") != null) {
+        // Gateway 1037+ uses hyphenated names; older Gateway/TWS uses space-separated.
+        JToggleButton liveBtn  = SwingUtils.findToggleButton(window, "Live Trading");
+        if (liveBtn  == null) liveBtn  = SwingUtils.findToggleButton(window, "Live-Trading");
+        JToggleButton paperBtn = SwingUtils.findToggleButton(window, "Paper Trading");
+        if (paperBtn == null) paperBtn = SwingUtils.findToggleButton(window, "Paper-Trading");
+        if (liveBtn != null && paperBtn != null) {
             // TWS 974 onwards uses toggle buttons rather than a combo box
             Utils.logToConsole("Setting Trading mode = " + tradingMode);
             if (tradingMode.equalsIgnoreCase(TradingModeManager.TRADING_MODE_LIVE)) {
-                SwingUtils.findToggleButton(window, "Live Trading").doClick();
+                liveBtn.doClick();
             } else {
-                SwingUtils.findToggleButton(window, "Paper Trading").doClick();
+                paperBtn.doClick();
             }
             return true;
         } else {

--- a/src/ibcalpha/ibc/GatewayLoginFrameHandler.java
+++ b/src/ibcalpha/ibc/GatewayLoginFrameHandler.java
@@ -30,11 +30,13 @@ final class GatewayLoginFrameHandler extends AbstractLoginHandler {
         if (! (window instanceof JFrame)) return false;
 
         return ((SwingUtils.titleContains(window, "IBKR Gateway") ||
-                    SwingUtils.titleContains(window, "IB Gateway") || 
+                    SwingUtils.titleContains(window, "IBKR-Gateway") ||      // Gateway 1037+
+                    SwingUtils.titleContains(window, "IB Gateway") ||
                     SwingUtils.titleContains(window, "Interactive Brokers Gateway")) &&
                (SwingUtils.findButton(window, "Login") != null ||
                 SwingUtils.findButton(window, "Log In") != null ||          // TWS 974+
-                SwingUtils.findButton(window, "Paper Log In") != null));    // TWS 974+
+                SwingUtils.findButton(window, "Paper Log In") != null ||    // TWS 974+
+                SwingUtils.findButton(window, "Paper-Login") != null));     // Gateway 1037+ (hyphenated)
     }
 
     @Override
@@ -119,6 +121,7 @@ final class GatewayLoginFrameHandler extends AbstractLoginHandler {
 
     private void switchToFIX(Window window) throws IbcException {
         JToggleButton button = SwingUtils.findToggleButton(window, "FIX CTCI");
+        if (button == null) button = SwingUtils.findToggleButton(window, "FIX-CTCI");   // Gateway 1037+
         if (button == null) throw new IbcException("FIX CTCI selector");
 
         if (! button.isSelected()) {

--- a/src/ibcalpha/ibc/ReconnectDataOrAccountConfirmationDialogHandler.java
+++ b/src/ibcalpha/ibc/ReconnectDataOrAccountConfirmationDialogHandler.java
@@ -46,10 +46,12 @@ public class ReconnectDataOrAccountConfirmationDialogHandler implements WindowHa
     public boolean recogniseWindow(Window window) {
         if (! (window instanceof JDialog)) return false;
 
-        return ((SwingUtils.titleContains(window, "IBKR Trader Workstation") 
+        return ((SwingUtils.titleContains(window, "IBKR Trader Workstation")
                 ||
-                SwingUtils.titleContains(window, "IBKR Gateway"))
-                && 
+                SwingUtils.titleContains(window, "IBKR Gateway")
+                ||
+                SwingUtils.titleContains(window, "IBKR-Gateway"))                       // Gateway 1037+
+                &&
                 (SwingUtils.findLabel(window, "Are you sure you want to execute \"simulate") != null)
                 );
     }


### PR DESCRIPTION
## Problem

IB Gateway **10.37** renamed several UI controls to use hyphens instead of spaces. IBC 3.23.0 doesn't recognise the new forms, so `GatewayLoginFrameHandler.recogniseWindow()` returns `false`, the login handler never fires, and IBC eventually exits with code **1112** (`LOGIN_DIALOG_DISPLAY_TIMED_OUT`).

Diagnostic signature in the IBC log:

```
IBC: detected frame entitled: IBKR-Gateway; event=Opened
... (60s of silence — no 'Setting user name', no click attempt)
IBC: Exiting with exit code=1112
Check for login dialog display timeout
```

## Affected controls

Confirmed by enabling `LogComponents=open` and dumping the live Swing tree of Gateway 10.37.1q's login window:

| Element | Old (still works) | New (Gateway 1037+) |
|---|---|---|
| Window title | `IBKR Gateway` | `IBKR-Gateway` |
| Login button | `Paper Log In` | `Paper-Login` |
| Mode toggles | `Live Trading` / `Paper Trading` | `Live-Trading` / `Paper-Trading` |
| API toggle | `FIX CTCI` | `FIX-CTCI` |

## Fix

Purely additive — keep the existing strings, add the new ones as fallbacks. Touches three files:

- `GatewayLoginFrameHandler` — title + paper-login button + FIX-CTCI toggle
- `AbstractLoginHandler` — generic `findLoginButton` + `setTradingMode` toggles
- `ReconnectDataOrAccountConfirmationDialogHandler` — title

Older Gateway/TWS versions remain matched by the existing space-separated strings.

## Verification

End-to-end test on Gateway **10.37.1q** (Windows, paper trading, German locale):

- Kill all Gateway/IBC processes
- Fire `StartGateway.bat`
- t+10s: IBC log shows in order — `Setting user name` → `Setting password` → `Login attempt` → `Authentifizierung...` → port 4002 LISTENING
- Held LISTENING continuously for 2 minutes, same Java PID, no drops

Before the patch: every IBC start exited 1112 after exactly 60s; after the patch: full auto-login completes in ~10s.